### PR TITLE
Setup access policies for Bridge Worker

### DIFF
--- a/cf_templates/eb_app.yml
+++ b/cf_templates/eb_app.yml
@@ -251,6 +251,7 @@ Resources:
               - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-SynapseSurveyTables'
               - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-UploadSchema'
               - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-UploadSchema/index/studyId-index'
+              - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-FitBitTables'
   AWSIAMS3ManagedPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:

--- a/cf_templates/eb_app.yml
+++ b/cf_templates/eb_app.yml
@@ -136,6 +136,9 @@ Parameters:
   SynapseUser:
     Type: String
     Default: param_place_holder
+  UserDataBucket:
+    Type: String
+    Default: param_place_holder
 Resources:
   AWSEBConfigurationTemplate:
     Type: 'AWS::ElasticBeanstalk::ConfigurationTemplate'
@@ -231,6 +234,46 @@ Resources:
         Type: SQS/HTTP
   AWSS3AppDeployBucket:
     Type: 'AWS::S3::Bucket'
+  AWSIAMDynamoManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            Action:
+              - 'dynamodb:GetItem'
+              - 'dynamodb:Query'
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-exporter-SynapseTables'
+              - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-HealthId'
+              - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-Study'
+              - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-SynapseSurveyTables'
+              - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-UploadSchema'
+              - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-UploadSchema/index/studyId-index'
+  AWSIAMS3ManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            Action:
+              - 's3:PutObject'
+              - 's3:GetObject'
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:s3:::${UserDataBucket}/*'
+  AWSIAMSesManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            Action:
+              - 'ses:SendEmail'
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/*'
   AWSIAMServiceRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -265,6 +308,9 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier'
+        - !Ref AWSIAMDynamoManagedPolicy
+        - !Ref AWSIAMS3ManagedPolicy
+        - !Ref AWSIAMSesManagedPolicy
   AWSIAMInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
@@ -292,8 +338,10 @@ Resources:
     Type: 'AWS::IAM::Group'
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonSNSFullAccess
-        - arn:aws:iam::aws:policy/AmazonSQSFullAccess
+        - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier'
+        - !Ref AWSIAMDynamoManagedPolicy
+        - !Ref AWSIAMS3ManagedPolicy
+        - !Ref AWSIAMSesManagedPolicy
   AWSLBSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -334,3 +382,7 @@ Outputs:
     Value: !Ref AWSS3AppDeployBucket
     Export:
       Name: !Sub '${AWS::StackName}-AppDeployBucket'
+  UserDataBucket:
+    Value: !Ref UserDataBucket
+    Export:
+      Name: !Sub '${AWS::StackName}-UserDataBucket'

--- a/env_vars
+++ b/env_vars
@@ -20,4 +20,6 @@ export BridgeWorkerStudy_uat=api
 export SynapseUser_develop=BridgeExporterDev
 export SynapseUser_prod=BridgeExporter
 export SynapseUser_uat=BridgeExporterStaging
-
+export UserDataBucket_develop=org-sagebridge-userdata-develop
+export UserDataBucket_prod=org-sagebridge-userdata-prod
+export UserDataBucket_uat=org-sagebridge-userdata-uat

--- a/update_cf_stack.sh
+++ b/update_cf_stack.sh
@@ -9,6 +9,7 @@ eval export "BridgeWorkerPassword=\$BridgeWorkerPassword_$TRAVIS_BRANCH"
 eval export "Env=\$Env_$TRAVIS_BRANCH"
 eval export "SynapseApiKey=\$SynapseApiKey_$TRAVIS_BRANCH"
 eval export "SynapseUser=\$SynapseUser_$TRAVIS_BRANCH"
+eval export "UserDataBucket=\$UserDataBucket_$TRAVIS_BRANCH"
 
 # deploy with evaluated vars
 aws cloudformation update-stack \
@@ -27,4 +28,5 @@ ParameterKey=EC2InstanceType,ParameterValue=t2.micro \
 ParameterKey=Env,ParameterValue=$Env \
 ParameterKey=AwsSolutionStackName,ParameterValue="$AwsSolutionStackName" \
 ParameterKey=SynapseApiKey,ParameterValue=$SynapseApiKey \
-ParameterKey=SynapseUser,ParameterValue=$SynapseUser
+ParameterKey=SynapseUser,ParameterValue=$SynapseUser \
+ParameterKey=UserDataBucket,ParameterValue=$UserDataBucket


### PR DESCRIPTION
Add access policies to EB managed EC2 instances to allow the Bridge worker
running on those EC2 machines to have access to AWS resources.