### PR TITLE
Fix resource creation timing issue

### DIFF
--- a/cf_templates/eb_app.yml
+++ b/cf_templates/eb_app.yml
@@ -422,8 +422,18 @@ Resources:
           FromPort: '80'
           ToPort: '80'
           SourceSecurityGroupId: !Ref AWSLBSecurityGroup
+  AWSLogsTomcatLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: !Join
+        - '/'
+        - - /aws/elasticbeanstalk
+          - !Ref 'AWS::StackName'
+          - var/log/tomcat8/catalina.out
+      RetentionInDays: 90
   AWSCWRequestActivityMetricFilter:
     Type: "AWS::Logs::MetricFilter"
+    DependsOn: AWSLogsTomcatLogGroup
     Properties:
       LogGroupName: !Join
         - '/'


### PR DESCRIPTION
CF may fail to create the Metric filter if the log group isn't
available yet.  Make the log group a dependency of the metric filter.