### PR TITLE
Activity alarm needs 2 evaluation periods

### DIFF
--- a/cf_templates/eb_app.yml
+++ b/cf_templates/eb_app.yml
@@ -479,7 +479,7 @@ Resources:
       AlarmActions:
         - !Ref AWSSNSTopic
       ComparisonOperator: LessThanThreshold
-      EvaluationPeriods: 1
+      EvaluationPeriods: 2
       MetricName: !Join
         - '-'
         - - !Ref 'AWS::StackName'


### PR DESCRIPTION
This alarm fired because the log message we're scanning on doesn't show up exactly once every 24 hours. There is some slight variation. On May 16, the log message showed up at 07:28:48am. On May 17, the log message showed up at 07:30:54am. Because CloudWatch uses a continuous window, there isa 2 minute window where the alarm can fired.

We can solve this by requiring 2 consective periods before the alarms fire. This means we might not notice single days where the Reporter fails to run, and we might not be notified that the Reporter has stopped running for at least 24 hours, but a less sensitive alarm is better than a flaky alarm. If we need something more sophisticated, we can consider building that in the future.