### PR TITLE
Remove AWSCWRequestActivityAlarm

### DIFF
--- a/templates/bridgeworker.yaml
+++ b/templates/bridgeworker.yaml
@@ -472,23 +472,6 @@ Resources:
             - '-'
             - - !Ref 'AWS::StackName'
               - RequestActivityCount
-  AWSCWRequestActivityAlarm:
-    Type: "AWS::CloudWatch::Alarm"
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref AWSSNSTopic
-      ComparisonOperator: LessThanThreshold
-      EvaluationPeriods: 2
-      MetricName: !Join
-        - '-'
-        - - !Ref 'AWS::StackName'
-          - RequestActivityCount
-      Namespace: LogMetrics/RequestActivity
-      Period: 86400
-      Statistic: Maximum
-      Threshold: 1
-      TreatMissingData: notBreaching
   AWSCWRequestErrorMetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsTomcatLogGroup


### PR DESCRIPTION
Apparently, we can't have a period more than 24 hours, which means this alarm doesn't work. Since the alarm with only one 24-hour period is noisy, we've decided to remove this alarm and figure out a different way to monitor this.