### PR TITLE
param validation of required values

### DIFF
--- a/templates/bridgeworker.yaml
+++ b/templates/bridgeworker.yaml
@@ -24,32 +24,28 @@ AWSTemplateFormatVersion: 2010-09-09
 Parameters:
   AwsDefaultVpcId:
     Description: The AWS account's default VPC id
-    Type: String
-    Default: param_place_holder
+    Type: "AWS::EC2::VPC::Id"
   AwsSnsNotificationEndpoint:
     Type: String
     Description: Email address for AWS SNS notifications
-    Default: param_place_holder
   AwsSolutionStackName:
     Description: The AWS Solution Stack
     Type: String
-    Default: param_place_holder
   BridgeEnv:
     Type: String
-    Default: param_place_holder
+    Default: dev
   BridgeUser:
     Type: String
-    Default: param_place_holder
+    Default: heroku
   BridgeWorkerEmail:
     Type: String
-    Default: param_place_holder
+    Default: bridgeit+worker@sagebase.org
   BridgeWorkerPassword:
     Type: String
-    Default: param_place_holder
     NoEcho: true
   BridgeWorkerStudy:
     Type: String
-    Default: param_place_holder
+    Default: api
   EC2InstanceType:
     Type: String
     Description: Instance type to use for Elastic Beanstalk Instances
@@ -128,27 +124,21 @@ Parameters:
       - f1.16xlarge
   Env:
     Type: String
-    Default: param_place_holder
+    Default: develop
   NewRelicAppName:
     Type: String
-    Default: param_place_holder
   NewRelicLicenseKey:
     Type: String
-    Default: param_place_holder
     NoEcho: true
   SynapseApiKey:
     Type: String
-    Default: param_place_holder
     NoEcho: true
   SynapsePrincipalId:
     Type: String
-    Default: param_place_holder
   SynapseUser:
     Type: String
-    Default: param_place_holder
   UserDataBucket:
     Type: String
-    Default: param_place_holder
 Resources:
   AWSEBConfigurationTemplate:
     Type: 'AWS::ElasticBeanstalk::ConfigurationTemplate'


### PR DESCRIPTION
Remove "param_place_holder" default settings from parameters to
designate them as required parameters. Add some constraints to
allow cloudformation to validate the passed in values.