### PR TITLE
update worker permissions for User Data Download

### DIFF
--- a/templates/bridgeworker.yaml
+++ b/templates/bridgeworker.yaml
@@ -265,8 +265,10 @@ Resources:
           Version: '2012-10-17'
           Statement:
             Action:
+              - 'dynamodb:DeleteItem'
               - 'dynamodb:GetItem'
               - 'dynamodb:Query'
+              - 'dynamodb:UpdateItem'
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-exporter-SynapseTables'


### PR DESCRIPTION
User Data Download needs permissions to delete and update certain tables, so it can handle deleted Synapse tables. See https://sagebionetworks.jira.com/browse/BRIDGE-2129