### PR TITLE
suppress warning alarm

### DIFF
--- a/templates/bridgeworker.yaml
+++ b/templates/bridgeworker.yaml
@@ -551,41 +551,42 @@ Resources:
       Statistic: Sum
       Threshold: 10
       TreatMissingData: notBreaching
-  AWSCWRequestWarningMetricFilter:
-    Type: "AWS::Logs::MetricFilter"
-    DependsOn: AWSLogsTomcatLogGroup
-    Properties:
-      LogGroupName: !Join
-        - '/'
-        - - /aws/elasticbeanstalk
-          - !Ref 'AWS::StackName'
-          - var/log/tomcat8/catalina.out
-      FilterPattern: 'WARN'
-      MetricTransformations:
-        -
-          MetricValue: "1"
-          MetricNamespace: "LogMetrics/Warnings"
-          MetricName: !Join
-            - '-'
-            - - !Ref 'AWS::StackName'
-              - RequestWarningCount
-  AWSCWRequestWarningAlarm:
-    Type: "AWS::CloudWatch::Alarm"
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref AWSSNSTopic
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 1
-      MetricName: !Join
-        - '-'
-        - - !Ref 'AWS::StackName'
-          - RequestWarningCount
-      Namespace: LogMetrics/Warnings
-      Period: 3600
-      Statistic: Sum
-      Threshold: 100
-      TreatMissingData: notBreaching
+# Re-enable warning alarm when https://sagebionetworks.jira.com/browse/BRIDGE-2522 is fixed
+#  AWSCWRequestWarningMetricFilter:
+#    Type: "AWS::Logs::MetricFilter"
+#    DependsOn: AWSLogsTomcatLogGroup
+#    Properties:
+#      LogGroupName: !Join
+#        - '/'
+#        - - /aws/elasticbeanstalk
+#          - !Ref 'AWS::StackName'
+#          - var/log/tomcat8/catalina.out
+#      FilterPattern: 'WARN'
+#      MetricTransformations:
+#        -
+#          MetricValue: "1"
+#          MetricNamespace: "LogMetrics/Warnings"
+#          MetricName: !Join
+#            - '-'
+#            - - !Ref 'AWS::StackName'
+#              - RequestWarningCount
+#  AWSCWRequestWarningAlarm:
+#    Type: "AWS::CloudWatch::Alarm"
+#    Properties:
+#      ActionsEnabled: true
+#      AlarmActions:
+#        - !Ref AWSSNSTopic
+#      ComparisonOperator: GreaterThanOrEqualToThreshold
+#      EvaluationPeriods: 1
+#      MetricName: !Join
+#        - '-'
+#        - - !Ref 'AWS::StackName'
+#          - RequestWarningCount
+#      Namespace: LogMetrics/Warnings
+#      Period: 3600
+#      Statistic: Sum
+#      Threshold: 100
+#      TreatMissingData: notBreaching
   AWSCWHeartbeatMetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsTomcatLogGroup


### PR DESCRIPTION
I added sleep data to the FitBit Worker, but forgot that CRF doesn't have access to the sleep scope. This leads to a bunch of warnings. For now, disable the warnings. We'll add per-study FitBit configs in the next sprint (https://sagebionetworks.jira.com/browse/BRIDGE-2522) and re-enable the warnings.