### PR TITLE
re-enable warning alarm

### DIFF
--- a/templates/bridgeworker.yaml
+++ b/templates/bridgeworker.yaml
@@ -527,42 +527,41 @@ Resources:
       Statistic: Sum
       Threshold: 10
       TreatMissingData: notBreaching
-# Re-enable warning alarm when https://sagebionetworks.jira.com/browse/BRIDGE-2522 is fixed
-#  AWSCWRequestWarningMetricFilter:
-#    Type: "AWS::Logs::MetricFilter"
-#    DependsOn: AWSLogsTomcatLogGroup
-#    Properties:
-#      LogGroupName: !Join
-#        - '/'
-#        - - /aws/elasticbeanstalk
-#          - !Ref 'AWS::StackName'
-#          - var/log/tomcat8/catalina.out
-#      FilterPattern: 'WARN'
-#      MetricTransformations:
-#        -
-#          MetricValue: "1"
-#          MetricNamespace: "LogMetrics/Warnings"
-#          MetricName: !Join
-#            - '-'
-#            - - !Ref 'AWS::StackName'
-#              - RequestWarningCount
-#  AWSCWRequestWarningAlarm:
-#    Type: "AWS::CloudWatch::Alarm"
-#    Properties:
-#      ActionsEnabled: true
-#      AlarmActions:
-#        - !Ref AWSSNSTopic
-#      ComparisonOperator: GreaterThanOrEqualToThreshold
-#      EvaluationPeriods: 1
-#      MetricName: !Join
-#        - '-'
-#        - - !Ref 'AWS::StackName'
-#          - RequestWarningCount
-#      Namespace: LogMetrics/Warnings
-#      Period: 3600
-#      Statistic: Sum
-#      Threshold: 100
-#      TreatMissingData: notBreaching
+  AWSCWRequestWarningMetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    DependsOn: AWSLogsTomcatLogGroup
+    Properties:
+      LogGroupName: !Join
+        - '/'
+        - - /aws/elasticbeanstalk
+          - !Ref 'AWS::StackName'
+          - var/log/tomcat8/catalina.out
+      FilterPattern: 'WARN'
+      MetricTransformations:
+        -
+          MetricValue: "1"
+          MetricNamespace: "LogMetrics/Warnings"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - RequestWarningCount
+  AWSCWRequestWarningAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AWSSNSTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - RequestWarningCount
+      Namespace: LogMetrics/Warnings
+      Period: 3600
+      Statistic: Sum
+      Threshold: 100
+      TreatMissingData: notBreaching
   AWSCWHeartbeatMetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsTomcatLogGroup


### PR DESCRIPTION
This is the reverse of https://github.com/Sage-Bionetworks/BridgeWorkerPlatform-infra/pull/43 We had previously disabled the Warning alarm because I added sleep and forgot that CRF didn't have sleep, so it was generating hundreds of warnings per day.

Now that we've added Per-Study FitBit scopes (see https://sagebionetworks.jira.com/browse/BRIDGE-2522), the warnings have gone away, and we can re-enable the warning alarm.