### PR TITLE
fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
-  - pip install cfn-lint sceptre sceptre-ssm-resolver
+  - pip install cfn-lint==0.28.0 sceptre sceptre-ssm-resolver
 stages:
   - name: validate
   - name: deploy


### PR DESCRIPTION
newer version of cfn-lint introduced a library conflict to
the python environment. fix by pinning cfn-lint version.