### PR TITLE
BRIDGE-3165 Add JVM setting for heap size

### DIFF
--- a/config/prod/bridgeworker.yaml
+++ b/config/prod/bridgeworker.yaml
@@ -11,6 +11,7 @@ parameters:
   BridgeWorkerPassword: !ssm /bridgeworker-prod/BridgeWorkerPassword
   EC2InstanceType: t3a.2xlarge
   Env: production
+  JavaHeapSize: 24g
   NewRelicAppName: bridgeworker-prod
   NewRelicLicenseKey: !ssm /infra/NewRelicLicenseKey
   RawHealthDataBucket: org-sagebridge-rawhealthdata-prod

--- a/templates/bridgeworker.yaml
+++ b/templates/bridgeworker.yaml
@@ -31,6 +31,9 @@ Parameters:
   Env:
     Type: String
     Default: develop
+  JavaHeapSize:
+    Type: String
+    Default: 1g
   NewRelicAppName:
     Type: String
   NewRelicLicenseKey:
@@ -102,6 +105,12 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:cloudwatch:logs'
           OptionName: RetentionInDays
           Value: '90'
+        - Namespace: 'aws:elasticbeanstalk:container:tomcat:jvmoptions'
+          OptionName: Xms
+          Value: !Ref JavaHeapSize
+        - Namespace: 'aws:elasticbeanstalk:container:tomcat:jvmoptions'
+          OptionName: Xmx
+          Value: !Ref JavaHeapSize
         - Namespace: 'aws:elasticbeanstalk:hostmanager'
           OptionName: LogPublicationControl
           Value: 'true'


### PR DESCRIPTION
Adds JVM setting for heap size. Sets this to 1gb in dev and staging and 24gb in prod. (Prod boxes have 32gb RAM.)

Min and Max heap size are set to the same value, so that Java doesn't spend time resizing the heap and doing memcopy.

This is needed as a stopgap solution for https://sagebionetworks.jira.com/browse/BRIDGE-3165