### PR TITLE
[IT-5167] Migrate from AL2 to AL2023

### DIFF
--- a/templates/bridgeworker.yaml
+++ b/templates/bridgeworker.yaml
@@ -65,7 +65,7 @@ Resources:
     Type: 'AWS::ElasticBeanstalk::ConfigurationTemplate'
     Properties:
       ApplicationName: !Ref AWSEBApplication
-      SolutionStackName: '64bit Amazon Linux 2 v4.14.0 running Tomcat 9 Corretto 8'
+      SolutionStackName: '64bit Amazon Linux 2023 v5.14.1 running Tomcat 9 Corretto 8'
       OptionSettings:
         # EB environment options
         - Namespace: 'aws:elasticbeanstalk:xray'


### PR DESCRIPTION
The Amazon Linux 2 platforms will be deprecated by AWS on June 30th 2026. Migrate to the Amazon Linux 2023 platform.